### PR TITLE
Reduced the number of tabs in the rules for switch. Wrapped the authorization form with a form

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -51,7 +51,7 @@ module.exports = {
         'func-name-matching': 1,
         'func-names': 2,
         'func-style': [2, 'declaration', { allowArrowFunctions: true }],
-        indent: [2, 4, { SwitchCase: 2 }],
+        indent: [2, 4, { SwitchCase: 1 }],
         'key-spacing': 2,
         'keyword-spacing': 2,
         'linebreak-style': 2,

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -173,6 +173,20 @@ const AuthPage = () => {
         setLoading(false);
     }
 
+    async function submitForm() {
+        switch (state) {
+            case AuthState.number:
+                await confirmNumber();
+                break;
+            case AuthState.code:
+                await confirmCode();
+                break;
+            case AuthState.password:
+                await confirmPassword();
+                break;
+        }
+    }
+
     const InputItemRow = ({ visibleStates = [], disabledStates = [], error, setValue, type, label }: IInputItemRow) => {
         if (!visibleStates.includes(state)) {
             return null;
@@ -189,7 +203,7 @@ const AuthPage = () => {
         );
     };
 
-    const ButtonItemRow = ({ visibleStates = [], disabledValue = '', onClick, name }: IButtonItemRow) => {
+    const ButtonItemRow = ({ visibleStates = [], disabledValue = '', name }: IButtonItemRow) => {
         if (!visibleStates.includes(state)) {
             return null;
         }
@@ -199,7 +213,7 @@ const AuthPage = () => {
                 fullWidth
                 variant="outline"
                 mt="xs"
-                onClick={onClick}
+                type="submit"
                 disabled={(disabledValue || '').length === 0 || isLoading}
             >
                 {name}
@@ -218,47 +232,45 @@ const AuthPage = () => {
     return (
         <Container>
             <Center py={10}>{t('auth_page.description')}</Center>
-
-            {InputItemRow({
-                label: t('auth_page.input_number'),
-                visibleStates: [AuthState.number, AuthState.code, AuthState.password],
-                disabledStates: [AuthState.code, AuthState.password],
-                error: numberError,
-                setValue: setNumber
-            })}
-            {InputItemRow({
-                label: t('auth_page.input_code'),
-                visibleStates: [AuthState.code, AuthState.password],
-                disabledStates: [AuthState.password],
-                error: codeError,
-                setValue: setCode
-            })}
-            {InputItemRow({
-                label: t('auth_page.input_password'),
-                visibleStates: [AuthState.password],
-                disabledStates: [],
-                type: 'password',
-                error: passwordError,
-                setValue: setPassword
-            })}
-            {ButtonItemRow({
-                visibleStates: [AuthState.number],
-                disabledValue: number,
-                onClick: confirmNumber,
-                name: t('auth_page.button_send_code')
-            })}
-            {ButtonItemRow({
-                visibleStates: [AuthState.code],
-                disabledValue: code,
-                onClick: confirmCode,
-                name: t('auth_page.button_confirm_code')
-            })}
-            {ButtonItemRow({
-                visibleStates: [AuthState.password],
-                disabledValue: password,
-                onClick: confirmPassword,
-                name: t('auth_page.button_confirm_password')
-            })}
+            <form onSubmit={submitForm}>
+                {InputItemRow({
+                    label: t('auth_page.input_number'),
+                    visibleStates: [AuthState.number, AuthState.code, AuthState.password],
+                    disabledStates: [AuthState.code, AuthState.password],
+                    error: numberError,
+                    setValue: setNumber
+                })}
+                {InputItemRow({
+                    label: t('auth_page.input_code'),
+                    visibleStates: [AuthState.code, AuthState.password],
+                    disabledStates: [AuthState.password],
+                    error: codeError,
+                    setValue: setCode
+                })}
+                {InputItemRow({
+                    label: t('auth_page.input_password'),
+                    visibleStates: [AuthState.password],
+                    disabledStates: [],
+                    type: 'password',
+                    error: passwordError,
+                    setValue: setPassword
+                })}
+                {ButtonItemRow({
+                    visibleStates: [AuthState.number],
+                    disabledValue: number,
+                    name: t('auth_page.button_send_code')
+                })}
+                {ButtonItemRow({
+                    visibleStates: [AuthState.code],
+                    disabledValue: code,
+                    name: t('auth_page.button_confirm_code')
+                })}
+                {ButtonItemRow({
+                    visibleStates: [AuthState.password],
+                    disabledValue: password,
+                    name: t('auth_page.button_confirm_password')
+                })}
+            </form>
 
             {state === AuthState.number && (
                 <>


### PR DESCRIPTION
Well, here it's ugm pukm 👉👈🥺.

In short, I wrapped the authorization form with a html form, changed the logic from onClick to onSubmit, so that you could not
need to poke constantly at the buttons "send message", etc., and just click the enter + I like the look better).

Also in the eslint rules I reduced the number of tabs in the switch case by 1, because this macaca asked to put 2 tabs that were the size of Everest.